### PR TITLE
fix syncing for plain wandb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3 (18.01.2023)
+
+### Fixed
+
+- Fixed path to run directory when syncing with `wandb` and `TriggerWandbSyncHook`
+  (without specifying explicit paths). See [#30](https://github.com/klieret/wandb-offline-sync-hook/issues/30)
+  for more information
+
 ## 1.0.2 (01.01.2023)
 
 ### Changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = wandb_osh
-version = 1.0.2
+version = 1.0.3
 description = Trigger wandb offline syncs from a compute node without internet
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/wandb_osh/hooks.py
+++ b/src/wandb_osh/hooks.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import wandb
 
+from wandb_osh.util.hash_id import hash_id
 from wandb_osh.util.log import logger
 
 _comm_default_dir = Path("~/.wandb_osh_command_dir").expanduser()
@@ -31,8 +32,9 @@ class TriggerWandbSyncHook:
         """
         if logdir is None:
             logdir = wandb.run.dir
-        trial_dir = Path(logdir)
-        command_file = self.communication_dir / f"{trial_dir.name}.command"
+        trial_dir = Path(logdir).resolve()
+        cmd_fname = hash_id(str(trial_dir)) + ".command"
+        command_file = self.communication_dir / cmd_fname
         if command_file.is_file():
             logger.warning(
                 "Syncing not active or too slow: Command %s file still exists",

--- a/src/wandb_osh/hooks.py
+++ b/src/wandb_osh/hooks.py
@@ -31,7 +31,9 @@ class TriggerWandbSyncHook:
             None
         """
         if logdir is None:
-            logdir = wandb.run.dir
+            # run.dir actually points to the `/files` subdirectory of the run,
+            # but we need the directory above that.
+            logdir = Path(wandb.run.dir).parent.resolve()
         trial_dir = Path(logdir).resolve()
         cmd_fname = hash_id(str(trial_dir)) + ".command"
         command_file = self.communication_dir / cmd_fname

--- a/src/wandb_osh/test_hooks.py
+++ b/src/wandb_osh/test_hooks.py
@@ -8,8 +8,8 @@ from wandb_osh.hooks import TriggerWandbSyncHook
 def test_trigger_wandb_sync_hook(tmp_path, caplog):
     hook = TriggerWandbSyncHook(tmp_path)
     hook("/test/123")
-    assert (tmp_path / "123.command").is_file()
-    assert (tmp_path / "123.command").read_text() == "/test/123"
+    assert (tmp_path / "d2d46f.command").is_file()
+    assert (tmp_path / "d2d46f.command").read_text() == "/test/123"
     with caplog.at_level(logging.WARNING):
         hook("/test/123")
     assert "Syncing not active or too slow" in caplog.text

--- a/src/wandb_osh/test_ray_hooks.py
+++ b/src/wandb_osh/test_ray_hooks.py
@@ -19,8 +19,8 @@ def test_trigger_wandb_sync_hook(tmp_path, caplog):
     trial = MockTrial(logdir="/test/123")
 
     hook.log_trial_result(0, trial, {})  # type: ignore
-    assert (tmp_path / "123.command").is_file()
-    assert (tmp_path / "123.command").read_text() == "/test/123"
+    assert (tmp_path / "d2d46f.command").is_file()
+    assert (tmp_path / "d2d46f.command").read_text() == "/test/123"
     with caplog.at_level(logging.WARNING):
         hook.log_trial_result(0, trial, {})  # type: ignore
     assert "Syncing not active or too slow" in caplog.text

--- a/src/wandb_osh/util/hash_id.py
+++ b/src/wandb_osh/util/hash_id.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import hashlib
+
+
+def hash_id(string: str, length=6) -> str:
+    """Hash a string to a short string"""
+    return hashlib.sha256(string.encode()).hexdigest()[:length]


### PR DESCRIPTION
In reference to #30 

- 🐛 Avoid clashes of cmd file by hashing full path
- 🐛 Fix: Wandb points to the /files subdir
- 🔖 Release v1.0.3
