### PR TITLE
Add bounded concurrent syncing with --max-workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add bounded concurrent syncing to avoid one long `wandb sync` blocking other runs.
+  Configure with the new `--max-workers` CLI option.
+
 ## 1.2.2 (21.03.2024)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ You can add options to the `wandb sync` call by placing them after `--`. For exa
 wandb-osh -- --sync-all
 ```
 
+If you have many runs and want to sync multiple runs in parallel, increase the
+maximum number of concurrent syncs:
+
+```bash
+wandb-osh --max-workers 4 -- --sync-all
+```
+
 ## ❓ Q & A
 
 > I get the warning "wandb: NOTE: use wandb sync --sync-all to sync 1 unsynced runs from local directory."

--- a/src/wandb_osh/cli.py
+++ b/src/wandb_osh/cli.py
@@ -31,6 +31,15 @@ def _get_parser() -> ArgumentParser:
         help="Timeout for wandb sync. If <=0, no timeout.",
     )
     parser.add_argument(
+        "--max-workers",
+        default=1,
+        type=int,
+        help=(
+            "Maximum number of concurrent `wandb sync` processes. "
+            "Increase to avoid one long sync blocking all others."
+        ),
+    )
+    parser.add_argument(
         "wandb_options",
         nargs="*",
         help="Options to be passed on to `wandb sync`, e.g. `--sync-all`. When "
@@ -48,6 +57,7 @@ def main(argv=None) -> None:
         wait=args.wait,
         wandb_options=args.wandb_options,
         timeout=args.timeout,
+        max_workers=args.max_workers,
     )
     wandb_osh.loop()
 

--- a/src/wandb_osh/syncer.py
+++ b/src/wandb_osh/syncer.py
@@ -79,8 +79,12 @@ class WandbSyncer:
                 self._schedule(executor)
                 time.sleep(0.25)
                 for cf in command_files:
-                    if cf.is_file():
-                        cf.unlink()
+                    try:
+                        if cf.is_file():
+                            cf.unlink()
+                    except FileNotFoundError:
+                        # Another process may have already removed it.
+                        pass
                 if "PYTEST_CURRENT_TEST" in os.environ:
                     self._wait_for_all()
                     break

--- a/src/wandb_osh/syncer.py
+++ b/src/wandb_osh/syncer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from os import PathLike
 from pathlib import Path
 
@@ -19,6 +20,7 @@ class WandbSyncer:
         wandb_options: list[str] | None = None,
         *,
         timeout: int | float = 120,
+        max_workers: int = 1,
     ):
         """Class for interpreting command files and triggering
         `wandb sync`.
@@ -28,13 +30,19 @@ class WandbSyncer:
             wait: Minimal time to wait before scanning command dir again
             wandb_options: Options to pass on to wandb
             timeout: Timeout for wandb sync. If <=0, no timeout.
+            max_workers: Maximum number of concurrent sync processes.
         """
         if wandb_options is None:
             wandb_options = []
+        if max_workers < 1:
+            raise ValueError("max_workers must be >= 1")
         self.command_dir = Path(command_dir)
         self.wait = wait
         self.wandb_options = wandb_options
         self._timeout = timeout
+        self.max_workers = max_workers
+        self._pending: set[Path] = set()
+        self._in_progress: dict[Future, Path] = {}
 
     def sync(self, dir: PathLike) -> None:
         """Sync a directory. Thin wrapper around the `sync_dir` function.
@@ -49,39 +57,70 @@ class WandbSyncer:
         logger.info(
             "wandb-osh v%s, starting to watch %s", __version__, self.command_dir
         )
-        while True:
-            start_time = time.time()
-            self.command_dir.mkdir(parents=True, exist_ok=True)
-            command_files = []
-            targets = []
-            for command_file in self.command_dir.glob("*.command"):
-                target = Path(command_file.read_text())
-                command_files.append(command_file)
-                if not target.is_dir():
-                    logger.error(
-                        "Command file %s points to non-existing directory %s",
-                        command_file,
-                        target,
-                    )
-                    continue
-                targets.append(target)
-            for target in set(targets):
-                logger.info("Syncing %s...", target)
-                try:
-                    self.sync(target)
-                except subprocess.TimeoutExpired:
-                    # try again later
-                    logger.warning("Syncing %s timed out. Trying later.", target)
-                    from wandb_osh.hooks import TriggerWandbSyncHook
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            while True:
+                start_time = time.time()
+                self.command_dir.mkdir(parents=True, exist_ok=True)
+                self._collect_done()
+                command_files = []
+                targets = []
+                for command_file in self.command_dir.glob("*.command"):
+                    target = Path(command_file.read_text())
+                    command_files.append(command_file)
+                    if not target.is_dir():
+                        logger.error(
+                            "Command file %s points to non-existing directory %s",
+                            command_file,
+                            target,
+                        )
+                        continue
+                    targets.append(target)
+                self._pending.update(targets)
+                self._schedule(executor)
+                time.sleep(0.25)
+                for cf in command_files:
+                    if cf.is_file():
+                        cf.unlink()
+                if "PYTEST_CURRENT_TEST" in os.environ:
+                    self._wait_for_all()
+                    break
+                time.sleep(max(0.0, (time.time() - start_time) - self.wait))
 
-                    TriggerWandbSyncHook(self.command_dir)(target)
-            time.sleep(0.25)
-            for cf in command_files:
-                if cf.is_file():
-                    cf.unlink()
-            if "PYTEST_CURRENT_TEST" in os.environ:
+    def _schedule(self, executor: ThreadPoolExecutor) -> None:
+        available = self.max_workers - len(self._in_progress)
+        if available <= 0 or not self._pending:
+            return
+        for target in list(self._pending):
+            if available <= 0:
                 break
-            time.sleep(max(0.0, (time.time() - start_time) - self.wait))
+            self._pending.remove(target)
+            logger.info("Syncing %s...", target)
+            future = executor.submit(self.sync, target)
+            self._in_progress[future] = target
+            available -= 1
+
+    def _collect_done(self) -> None:
+        done_futures = [f for f in self._in_progress if f.done()]
+        for future in done_futures:
+            target = self._in_progress.pop(future)
+            try:
+                future.result()
+            except subprocess.TimeoutExpired:
+                # try again later
+                logger.warning("Syncing %s timed out. Trying later.", target)
+                self._requeue(target)
+
+    def _requeue(self, target: PathLike) -> None:
+        from wandb_osh.hooks import TriggerWandbSyncHook
+
+        TriggerWandbSyncHook(self.command_dir)(target)
+        self._pending.add(Path(target))
+
+    def _wait_for_all(self) -> None:
+        if not self._in_progress:
+            return
+        wait(self._in_progress.keys())
+        self._collect_done()
 
 
 def sync_dir(

--- a/src/wandb_osh/syncer.py
+++ b/src/wandb_osh/syncer.py
@@ -65,7 +65,11 @@ class WandbSyncer:
                 command_files = []
                 targets = []
                 for command_file in self.command_dir.glob("*.command"):
-                    target = Path(command_file.read_text())
+                    try:
+                        target = Path(command_file.read_text())
+                    except FileNotFoundError:
+                        # File was removed between glob and read_text by another process.
+                        continue
                     command_files.append(command_file)
                     if not target.is_dir():
                         logger.error(

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
 import unittest
 import unittest.mock
 from pathlib import Path
+
+import pytest
 
 from wandb_osh.syncer import WandbSyncer
 from wandb_osh.util.log import set_log_level
@@ -40,3 +43,41 @@ def test_wandb_sync_timeout(tmp_path, caplog):
         with caplog.at_level(logging.DEBUG):
             ws.loop()
         assert "timed out. Trying later." in caplog.text
+
+
+def test_wandb_syncer_max_workers_concurrent(tmp_path):
+    tmp_path = Path(tmp_path)
+    ws = WandbSyncer(tmp_path, max_workers=2, wait=0)
+
+    for i in range(3):
+        target = tmp_path / f"run{i}"
+        target.mkdir(parents=True)
+        (tmp_path / f"{i}.command").write_text(str(target.resolve()))
+
+    started = []
+    lock = threading.Lock()
+    started_two = threading.Event()
+    release = threading.Event()
+
+    def slow_sync(target):
+        with lock:
+            started.append(target)
+            if len(started) >= 2:
+                started_two.set()
+        release.wait(timeout=2)
+
+    ws.sync = slow_sync
+
+    thread = threading.Thread(target=ws.loop, daemon=True)
+    thread.start()
+    assert started_two.wait(timeout=2)
+    with lock:
+        assert len(started) == 2
+    release.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+
+
+def test_wandb_syncer_invalid_max_workers(tmp_path):
+    with pytest.raises(ValueError):
+        WandbSyncer(tmp_path, max_workers=0)


### PR DESCRIPTION
I often have multiple runs at the same time, and found that one long `wandb sync` would be blocking the sync of my other (shorter) runs. I therefore added a concurrency feature to allow for syncing multiple runs at the same time. 

## Summary
  - Add bounded concurrent syncing in the watcher to avoid one long `wandb sync` blocking other runs.
  - Expose `--max-workers` CLI option (default 1, preserves current behavior).
  - Document the new option and add a changelog entry.
  - Add tests for concurrency scheduling and invalid `max_workers`.

## Possible improvement
The new concurrency kind of messes up the display when multiple `wandb sync` processes write to stdout at the same time. This could be solved by capturing the output of the `wandb sync` command and printing our own info in a more concurrency-friendly manner, but I chose to not do it as to limit code changes to the minimum.